### PR TITLE
Release v0.0.6

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version v0.0.6 (2023-09-21)
+
+### Chores and tidying
+
+- use separate access token for Semanticore workflow (#13) (f79fdadf)
+
 ## Version v0.0.5 (2023-09-21)
 
 ### Chores and tidying


### PR DESCRIPTION
# Release v0.0.6 🏆

## Summary

There are 1 🧹 chore commits since v0.0.5.

This is a patch 🩹 release.

Merge this pull request to commit the changelog and have Semanticore create a new release on the next pipeline run.

# Changelog

## Version v0.0.6 (2023-09-21)

### Chores and tidying

- use separate access token for Semanticore workflow (#13) (f79fdadf)

---

This changelog was generated by your friendly [Semanticore Release Bot](https://github.com/aoepeople/semanticore)
