### PR TITLE
Release v0.0.7

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version v0.0.7 (2023-09-21)
+
+### Tests
+
+- add starting scaffold for provider tests (#16) (43f89e7c)
+
 ## Version v0.0.6 (2023-09-21)
 
 ### Chores and tidying


### PR DESCRIPTION
# Release v0.0.7 🏆

## Summary

There are 1 🛡 test commits since v0.0.6.

This is a patch 🩹 release.

Merge this pull request to commit the changelog and have Semanticore create a new release on the next pipeline run.

# Changelog

## Version v0.0.7 (2023-09-21)

### Tests

- add starting scaffold for provider tests (#16) (43f89e7c)

---

This changelog was generated by your friendly [Semanticore Release Bot](https://github.com/aoepeople/semanticore)
