### PR TITLE
Release v0.0.8

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version v0.0.8 (2023-09-25)
+
+### Chores and tidying
+
+- provider setup (#18) (2fb12a54)
+
 ## Version v0.0.7 (2023-09-21)
 
 ### Tests


### PR DESCRIPTION
# Release v0.0.8 🏆

## Summary

There are 1 🧹 chore commits since v0.0.7.

This is a patch 🩹 release.

Merge this pull request to commit the changelog and have Semanticore create a new release on the next pipeline run.

# Changelog

## Version v0.0.8 (2023-09-25)

### Chores and tidying

- provider setup (#18) (2fb12a54)

---

This changelog was generated by your friendly [Semanticore Release Bot](https://github.com/aoepeople/semanticore)
