### PR TITLE
Release v0.0.9

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Version v0.0.9 (2024-04-22)
+
+### Ops and CI/CD
+
+- update Github action versions (#38) (8bb17746)
+
+### Chores and tidying
+
+- **deps:** Bump golang.org/x/net from 0.21.0 to 0.23.0 (#39) (8b5ccc14)
+- **deps:** Bump github.com/hashicorp/terraform-plugin-framework from 1.5.0 to 1.8.0 (#37) (48266cf1)
+- **deps:** Bump github.com/stretchr/testify from 1.8.4 to 1.9.0 (#32) (6518b70a)
+- **deps:** Bump github.com/hashicorp/terraform-plugin-go from 0.21.0 to 0.22.2 (#36) (17a25b76)
+- **deps:** Bump github.com/hashicorp/terraform-plugin-go from 0.19.0 to 0.21.0 (#29) (ce55a8fd)
+- **deps:** Bump github.com/hashicorp/terraform-plugin-framework from 1.4.2 to 1.5.0 (#28) (30aaf323)
+- **deps:** Bump github.com/hashicorp/terraform-plugin-framework from 1.4.1 to 1.4.2 (#25) (a9b779f9)
+- **deps:** Bump golang.org/x/net from 0.13.0 to 0.17.0 (#24) (d0dd4756)
+- **deps:** bump github.com/hashicorp/terraform-plugin-framework from 1.4.0 to 1.4.1 (#23) (44736571)
+- move API key injection to HTTP transport (#21) (f3ccb6f1)
+
 ## Version v0.0.8 (2023-09-25)
 
 ### Chores and tidying


### PR DESCRIPTION
# Release v0.0.9 🏆

## Summary

There are 1 🤖 devops, 10 🧹 chore commits since v0.0.8.

This is a patch 🩹 release.

Merge this pull request to commit the changelog and have Semanticore create a new release on the next pipeline run.

# Changelog

## Version v0.0.9 (2024-04-22)

### Ops and CI/CD

- update Github action versions (#38) (8bb17746)

### Chores and tidying

- **deps:** Bump golang.org/x/net from 0.21.0 to 0.23.0 (#39) (8b5ccc14)
- **deps:** Bump github.com/hashicorp/terraform-plugin-framework from 1.5.0 to 1.8.0 (#37) (48266cf1)
- **deps:** Bump github.com/stretchr/testify from 1.8.4 to 1.9.0 (#32) (6518b70a)
- **deps:** Bump github.com/hashicorp/terraform-plugin-go from 0.21.0 to 0.22.2 (#36) (17a25b76)
- **deps:** Bump github.com/hashicorp/terraform-plugin-go from 0.19.0 to 0.21.0 (#29) (ce55a8fd)
- **deps:** Bump github.com/hashicorp/terraform-plugin-framework from 1.4.2 to 1.5.0 (#28) (30aaf323)
- **deps:** Bump github.com/hashicorp/terraform-plugin-framework from 1.4.1 to 1.4.2 (#25) (a9b779f9)
- **deps:** Bump golang.org/x/net from 0.13.0 to 0.17.0 (#24) (d0dd4756)
- **deps:** bump github.com/hashicorp/terraform-plugin-framework from 1.4.0 to 1.4.1 (#23) (44736571)
- move API key injection to HTTP transport (#21) (f3ccb6f1)

---

This changelog was generated by your friendly [Semanticore Release Bot](https://github.com/aoepeople/semanticore)
